### PR TITLE
chore: Add diagnostic logging for CA certificate

### DIFF
--- a/src/lib/db-mysql.ts
+++ b/src/lib/db-mysql.ts
@@ -4,6 +4,10 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+console.log('--- DEBUG: MYSQL_CA_CERT ---');
+console.log(process.env.MYSQL_CA_CERT);
+console.log('--- END DEBUG ---');
+
 // Create a connection pool
 const pool = mysql.createPool({
   host: process.env.MYSQL_HOST,


### PR DESCRIPTION
This commit adds a console.log statement to print the value of the `MYSQL_CA_CERT` environment variable at runtime. This is intended to help debug a persistent SSL handshake error in the Netlify deployment environment by verifying if the certificate content is being correctly passed to the application.